### PR TITLE
Fix bornes des dates de publications

### DIFF
--- a/src/main/webapp/src/services/util/DateUtils.js
+++ b/src/main/webapp/src/services/util/DateUtils.js
@@ -149,5 +149,15 @@ class DateUtils {
       }
     }
   }
+
+  min (date1, date2) {
+    if (!date1) {
+      return date2
+    }
+    if (!date2) {
+      return date1
+    }
+    return this.getDateDifference(date1, date2) > 0 ? date1 : date2
+  }
 }
 export default new DateUtils()

--- a/src/main/webapp/src/views/manager/publish/content/Content.vue
+++ b/src/main/webapp/src/views/manager/publish/content/Content.vue
@@ -147,6 +147,7 @@ export default {
       endMinDate: null,
       defaultMaxDuration: null,
       maxDate: null,
+      startMaxDate: null,
       cropperConf: null,
       defaultCropperConf: {
         size: { w: 240, h: 240 },
@@ -184,6 +185,7 @@ export default {
       minDate: readonly(computed(() => this.minDate)),
       endMinDate: readonly(computed(() => this.endMinDate)),
       maxDate: readonly(computed(() => this.maxDate)),
+      startMaxDate: readonly(computed(() => this.startMaxDate)),
       setItem: (newItem) => {
         if (CommonUtils.isDefined(newItem) && CommonUtils.isDefined(newItem.type) &&
         (!CommonUtils.isDefined(this.item) || this.item == null || newItem.type !== this.item.type || newItem.startDate !== this.item.startDate)) {
@@ -286,17 +288,15 @@ export default {
       }
     },
     updateMinDate (item) {
-      if (CommonUtils.isDefined(item) && CommonUtils.isDefined(item.type) && CommonUtils.isDefined(item.startDate)) {
-        this.minDate = item.startDate
-        this.endMinDate = item.startDate
-        if (DateUtils.getDateDifference(this.today, this.minDate) <= 0) {
-          this.endMinDate = this.today
-        }
+      if (CommonUtils.isDefined(item) && CommonUtils.isDefined(item.type) && CommonUtils.isDefined(item.id) && item.id !== null && CommonUtils.isDefined(item.startDate)
+        && !(CommonUtils.isDefined(item.endDate) && item.endDate !== null && DateUtils.getDateDifference(item.endDate, this.today) > 0)) {
+        this.minDate = DateUtils.min(item.startDate, this.today)
       }
     },
     updateMaxDate (item) {
       if (CommonUtils.isDefined(item) && CommonUtils.isDefined(item.type) && CommonUtils.isDefined(item.startDate)) {
         this.maxDate = DateUtils.addDaysToLocalDate(item.startDate, this.defaultMaxDuration)
+        this.endMinDate = item.startDate
       }
     },
     changeContentType (oldValue) {
@@ -442,10 +442,13 @@ export default {
       this.endMinDate = DateUtils.addDaysToLocalDate(this.today, 0)
       this.defaultMaxDuration = this.publisher.context.redactor.nbDaysMaxDuration > 0 ? this.publisher.context.redactor.nbDaysMaxDuration : 365
       this.maxDate = DateUtils.addDaysToLocalDate(this.today, this.defaultMaxDuration)
+      // Pas de limite supérieure à la date de début
+      this.startMaxDate = null
 
       if ((this.item === null || this.item === undefined || CommonUtils.equals({}, this.item)) && this.contentData && this.contentData.item) {
         const item = Object.assign({}, this.contentData.item)
         this.updateMinDate(this.contentData.item)
+        this.updateMaxDate(this.contentData.item)
         item.highlight = this.highlight
         // update publisher information when modified
         item.organization = Object.assign({}, this.publisher.context.organization)

--- a/src/main/webapp/src/views/manager/publish/content/ContentAttachment.vue
+++ b/src/main/webapp/src/views/manager/publish/content/ContentAttachment.vue
@@ -45,7 +45,7 @@
             <div class="form-group col-md-4">
                 <label class="control-label" for="startDate">{{ $t('attachment.startDate') }}</label>
                 <input type="date" class="form-control" name="startDate" id="startDate" placeholder="jj/mm/aaaa" v-model="itemStartDate"
-                    required :min="formatDateToString(minDate)" :max="formatDateToString(item.endDate)">
+                    required :min="formatDateToString(minDate)" :max="formatDateToString(startMaxDate)">
                 <div class="invalid-feedback"
                     v-if="formValidator.hasError('startDate', formErrors.REQUIRED)">
                     {{ $t('entity.validation.required') }}
@@ -56,7 +56,7 @@
                 </div>
                 <div class="invalid-feedback"
                     v-if="formValidator.hasError('startDate', formErrors.MAX_DATE)">
-                    {{ $t('entity.validation.maxdate', { max: formatDateToIntString(item.endDate)}) }}
+                    {{ $t('entity.validation.maxdate', { max: formatDateToIntString(startMaxDate)}) }}
                 </div>
             </div>
             <div class="form-group col-md-4">
@@ -149,7 +149,7 @@ export default {
   },
   inject: [
     'publisher', 'item', 'setItem', 'setItemValidated', 'minDate', 'endMinDate', 'maxDate', 'linkedFilesToContent',
-    'setLinkedFilesToContent', 'progress', 'setProgress', 'progressStatus', 'uploadLinkedFile', 'deleteAttachment', 'authorizedMimeTypes'
+    'setLinkedFilesToContent', 'progress', 'setProgress', 'progressStatus', 'uploadLinkedFile', 'deleteAttachment', 'authorizedMimeTypes', 'startMaxDate'
   ],
   computed: {
     itemTitle: {
@@ -212,7 +212,7 @@ export default {
       this.formValidator.clear()
       this.formValidator.checkTextFieldValidity('title', this.item.title, 3, 200, true)
       this.formValidator.checkTextFieldValidity('summary', this.item.summary, 5, 512, true)
-      this.formValidator.checkDateFieldValidity('startDate', this.item.startDate, this.minDate, this.item.endDate, true)
+      this.formValidator.checkDateFieldValidity('startDate', this.item.startDate, this.minDate, this.startMaxDate, true)
       this.formValidator.checkDateFieldValidity('endDate', this.item.endDate, this.endMinDate, this.maxDate, !this.publisher.context.redactor.optionalPublishTime)
       this.formValidator.checkArrayFieldValidity('files', this.linkedFilesToContent, null, null, true)
       this.updateItemValidated()
@@ -305,12 +305,11 @@ export default {
       this.updateItemValidated()
     },
     'item.startDate' (newVal) {
-      this.formValidator.checkDateFieldValidity('startDate', newVal, this.minDate, this.item.endDate, true)
+      this.formValidator.checkDateFieldValidity('startDate', newVal, this.minDate, this.startMaxDate, true)
       this.formValidator.checkDateFieldValidity('endDate', this.item.endDate, this.endMinDate, this.maxDate, !this.publisher.context.redactor.optionalPublishTime)
       this.updateItemValidated()
     },
     'item.endDate' (newVal) {
-      this.formValidator.checkDateFieldValidity('startDate', this.item.startDate, this.minDate, newVal, true)
       this.formValidator.checkDateFieldValidity('endDate', newVal, this.endMinDate, this.maxDate, !this.publisher.context.redactor.optionalPublishTime)
       this.updateItemValidated()
     },

--- a/src/main/webapp/src/views/manager/publish/content/ContentFlash.vue
+++ b/src/main/webapp/src/views/manager/publish/content/ContentFlash.vue
@@ -61,7 +61,7 @@
             <div class="form-group col-md-4">
                 <label class="control-label" for="startDate">{{ $t('flash.startDate') }}</label>
                 <input type="date" class="form-control" name="startDate" id="startDate" placeholder="jj/mm/aaaa" v-model="itemStartDate"
-                    required :min="formatDateToString(minDate)" :max="formatDateToString(item.endDate)">
+                    required :min="formatDateToString(minDate)" :max="formatDateToString(startMaxDate)">
                 <div class="invalid-feedback"
                     v-if="formValidator.hasError('startDate', formErrors.REQUIRED)">
                     {{ $t('entity.validation.required') }}
@@ -72,7 +72,7 @@
                 </div>
                 <div class="invalid-feedback"
                     v-if="formValidator.hasError('startDate', formErrors.MAX_DATE)">
-                    {{ $t('entity.validation.maxdate', { max: formatDateToIntString(item.endDate)}) }}
+                    {{ $t('entity.validation.maxdate', { max: formatDateToIntString(startMaxDate)}) }}
                 </div>
             </div>
             <div class="form-group col-md-4">
@@ -222,7 +222,7 @@ export default {
   inject: [
     'publisher', 'item', 'setItem', 'progress', 'setProgress', 'progressStatus', 'setProgressStatus', 'content', 'setContent',
     'clearUpload', 'uploadLinkedFile', 'cropperConf', 'setItemValidated', 'imageSizeMax', 'fileSizeMax', 'linkedFilesToContent',
-    'setLinkedFilesToContent', 'manageUploadError', 'minDate', 'endMinDate', 'maxDate'
+    'setLinkedFilesToContent', 'manageUploadError', 'minDate', 'endMinDate', 'maxDate', 'startMaxDate'
   ],
   computed: {
     itemTitle: {
@@ -292,7 +292,7 @@ export default {
       this.formValidator.clear()
       this.formValidator.checkTextFieldValidity('title', this.item.title, 3, 200, true)
       this.formValidator.checkTextFieldValidity('summary', this.item.summary, 5, 512, true)
-      this.formValidator.checkDateFieldValidity('startDate', this.item.startDate, this.minDate, this.item.endDate, true)
+      this.formValidator.checkDateFieldValidity('startDate', this.item.startDate, this.minDate, this.startMaxDate, true)
       this.formValidator.checkDateFieldValidity('endDate', this.item.endDate, this.endMinDate, this.maxDate, !this.publisher.context.redactor.optionalPublishTime)
       this.formValidator.checkTextFieldValidity('body', CommonUtils.removeHtmlTags(this.item.body), 15, null, true)
       this.formValidator.checkTextFieldValidity('enclosure', this.item.enclosure, null, null, true)
@@ -412,12 +412,11 @@ export default {
       this.updateItemValidated()
     },
     'item.startDate' (newVal) {
-      this.formValidator.checkDateFieldValidity('startDate', newVal, this.minDate, this.item.endDate, true)
+      this.formValidator.checkDateFieldValidity('startDate', newVal, this.minDate, this.startMaxDate, true)
       this.formValidator.checkDateFieldValidity('endDate', this.item.endDate, this.endMinDate, this.maxDate, !this.publisher.context.redactor.optionalPublishTime)
       this.updateItemValidated()
     },
     'item.endDate' (newVal) {
-      this.formValidator.checkDateFieldValidity('startDate', this.item.startDate, this.minDate, newVal, true)
       this.formValidator.checkDateFieldValidity('endDate', newVal, this.endMinDate, this.maxDate, !this.publisher.context.redactor.optionalPublishTime)
       this.updateItemValidated()
     },

--- a/src/main/webapp/src/views/manager/publish/content/ContentMedia.vue
+++ b/src/main/webapp/src/views/manager/publish/content/ContentMedia.vue
@@ -61,7 +61,7 @@
             <div class="form-group col-md-4">
                 <label class="control-label" for="startDate">{{ $t('media.startDate') }}</label>
                 <input type="date" class="form-control" name="startDate" id="startDate" placeholder="jj/mm/aaaa" v-model="itemStartDate"
-                    required :min="formatDateToString(minDate)" :max="formatDateToString(item.endDate)">
+                    required :min="formatDateToString(minDate)" :max="formatDateToString(startMaxDate)">
                 <div class="invalid-feedback"
                     v-if="formValidator.hasError('startDate', formErrors.REQUIRED)">
                     {{ $t('entity.validation.required') }}
@@ -72,7 +72,7 @@
                 </div>
                 <div class="invalid-feedback"
                     v-if="formValidator.hasError('startDate', formErrors.MAX_DATE)">
-                    {{ $t('entity.validation.maxdate', { max: formatDateToIntString(item.endDate)}) }}
+                    {{ $t('entity.validation.maxdate', { max: formatDateToIntString(startMaxDate)}) }}
                 </div>
             </div>
             <div class="form-group col-md-4">
@@ -220,7 +220,7 @@ export default {
   },
   inject: [
     'publisher', 'item', 'setItem', 'progress', 'setProgress', 'progressStatus', 'setProgressStatus', 'content', 'setContent',
-    'minDate', 'endMinDate', 'maxDate', 'clearUpload', 'setItemValidated', 'uploadLinkedFile', 'authorizedMimeTypes'
+    'minDate', 'endMinDate', 'maxDate', 'clearUpload', 'setItemValidated', 'uploadLinkedFile', 'authorizedMimeTypes', 'startMaxDate'
   ],
   computed: {
     itemTitle: {
@@ -281,7 +281,7 @@ export default {
       this.formValidator.checkTextFieldValidity('title', this.item.title, 3, 200, true)
       this.formValidator.checkTextFieldValidity('summary', this.item.summary, 5, 512, true)
       this.formValidator.checkTextFieldValidity('enclosure', this.item.enclosure, null, null, true)
-      this.formValidator.checkDateFieldValidity('startDate', this.item.startDate, this.minDate, this.item.endDate, true)
+      this.formValidator.checkDateFieldValidity('startDate', this.item.startDate, this.minDate, this.startMaxDate, true)
       this.formValidator.checkDateFieldValidity('endDate', this.item.endDate, this.endMinDate, this.maxDate, !this.publisher.context.redactor.optionalPublishTime)
       this.updateItemValidated()
     },
@@ -411,12 +411,11 @@ export default {
       this.updateItemValidated()
     },
     'item.startDate' (newVal) {
-      this.formValidator.checkDateFieldValidity('startDate', newVal, this.minDate, this.item.endDate, true)
+      this.formValidator.checkDateFieldValidity('startDate', newVal, this.minDate, this.startMaxDate, true)
       this.formValidator.checkDateFieldValidity('endDate', this.item.endDate, this.endMinDate, this.maxDate, !this.publisher.context.redactor.optionalPublishTime)
       this.updateItemValidated()
     },
     'item.endDate' (newVal) {
-      this.formValidator.checkDateFieldValidity('startDate', this.item.startDate, this.minDate, newVal, true)
       this.formValidator.checkDateFieldValidity('endDate', newVal, this.endMinDate, this.maxDate, !this.publisher.context.redactor.optionalPublishTime)
       this.updateItemValidated()
     }

--- a/src/main/webapp/src/views/manager/publish/content/ContentNews.vue
+++ b/src/main/webapp/src/views/manager/publish/content/ContentNews.vue
@@ -57,7 +57,7 @@
             <div class="form-group col-md-4">
                 <label class="control-label" for="startDate">{{ $t('news.startDate') }}</label>
                 <input type="date" class="form-control" name="startDate" id="startDate" placeholder="jj/mm/aaaa" v-model="itemStartDate"
-                    required :min="formatDateToString(minDate)" :max="formatDateToString(item.endDate)">
+                    required :min="formatDateToString(minDate)" :max="formatDateToString(startMaxDate)">
                 <div class="invalid-feedback"
                     v-if="formValidator.hasError('startDate', formErrors.REQUIRED)">
                     {{ $t('entity.validation.required') }}
@@ -68,7 +68,7 @@
                 </div>
                 <div class="invalid-feedback"
                     v-if="formValidator.hasError('startDate', formErrors.MAX_DATE)">
-                    {{ $t('entity.validation.maxdate', { max: formatDateToIntString(item.endDate)}) }}
+                    {{ $t('entity.validation.maxdate', { max: formatDateToIntString(startMaxDate)}) }}
                 </div>
             </div>
             <div class="form-group col-md-4">
@@ -219,7 +219,7 @@ export default {
   inject: [
     'publisher', 'item', 'setItem', 'progress', 'setProgress', 'progressStatus', 'setProgressStatus', 'content', 'setContent',
     'clearUpload', 'uploadLinkedFile', 'cropperConf', 'setItemValidated', 'imageSizeMax', 'fileSizeMax', 'linkedFilesToContent',
-    'setLinkedFilesToContent', 'manageUploadError', 'minDate', 'endMinDate', 'maxDate'
+    'setLinkedFilesToContent', 'manageUploadError', 'minDate', 'endMinDate', 'maxDate', 'startMaxDate'
   ],
   computed: {
     itemTitle: {
@@ -289,7 +289,7 @@ export default {
       this.formValidator.clear()
       this.formValidator.checkTextFieldValidity('title', this.item.title, 3, 200, true)
       this.formValidator.checkTextFieldValidity('summary', this.item.summary, 5, 512, true)
-      this.formValidator.checkDateFieldValidity('startDate', this.item.startDate, this.minDate, this.item.endDate, true)
+      this.formValidator.checkDateFieldValidity('startDate', this.item.startDate, this.minDate, this.startMaxDate, true)
       this.formValidator.checkDateFieldValidity('endDate', this.item.endDate, this.endMinDate, this.maxDate, !this.publisher.context.redactor.optionalPublishTime)
       this.formValidator.checkTextFieldValidity('body', CommonUtils.removeHtmlTags(this.item.body), 15, null, true)
       this.updateItemValidated()
@@ -408,12 +408,11 @@ export default {
       this.updateItemValidated()
     },
     'item.startDate' (newVal) {
-      this.formValidator.checkDateFieldValidity('startDate', newVal, this.minDate, this.item.endDate, true)
+      this.formValidator.checkDateFieldValidity('startDate', newVal, this.minDate, this.startMaxDate, true)
       this.formValidator.checkDateFieldValidity('endDate', this.item.endDate, this.endMinDate, this.maxDate, !this.publisher.context.redactor.optionalPublishTime)
       this.updateItemValidated()
     },
     'item.endDate' (newVal) {
-      this.formValidator.checkDateFieldValidity('startDate', this.item.startDate, this.minDate, newVal, true)
       this.formValidator.checkDateFieldValidity('endDate', newVal, this.endMinDate, this.maxDate, !this.publisher.context.redactor.optionalPublishTime)
       this.updateItemValidated()
     },

--- a/src/main/webapp/src/views/manager/publish/content/ContentResource.vue
+++ b/src/main/webapp/src/views/manager/publish/content/ContentResource.vue
@@ -57,7 +57,7 @@
             <div class="form-group col-md-4">
                 <label class="control-label" for="startDate">{{ $t('resource.startDate') }}</label>
                 <input type="date" class="form-control" name="startDate" id="startDate" placeholder="jj/mm/aaaa" v-model="itemStartDate"
-                    required :min="formatDateToString(minDate)" :max="formatDateToString(item.endDate)">
+                    required :min="formatDateToString(minDate)" :max="formatDateToString(startMaxDate)">
                 <div class="invalid-feedback"
                     v-if="formValidator.hasError('startDate', formErrors.REQUIRED)">
                     {{ $t('entity.validation.required') }}
@@ -68,7 +68,7 @@
                 </div>
                 <div class="invalid-feedback"
                     v-if="formValidator.hasError('startDate', formErrors.MAX_DATE)">
-                    {{ $t('entity.validation.maxdate', { max: formatDateToIntString(item.endDate)}) }}
+                    {{ $t('entity.validation.maxdate', { max: formatDateToIntString(startMaxDate)}) }}
                 </div>
             </div>
             <div class="form-group col-md-4">
@@ -229,7 +229,7 @@ export default {
   },
   inject: [
     'publisher', 'item', 'setItem', 'progress', 'setProgress', 'progressStatus', 'setProgressStatus', 'content', 'setContent',
-    'minDate', 'endMinDate', 'maxDate', 'clearUpload', 'setItemValidated', 'uploadLinkedFile'
+    'minDate', 'endMinDate', 'maxDate', 'clearUpload', 'setItemValidated', 'uploadLinkedFile', 'startMaxDate'
   ],
   computed: {
     itemTitle: {
@@ -299,7 +299,7 @@ export default {
       this.formValidator.clear()
       this.formValidator.checkTextFieldValidity('title', this.item.title, 3, 200, true)
       this.formValidator.checkTextFieldValidity('summary', this.item.summary, 5, 512, true)
-      this.formValidator.checkDateFieldValidity('startDate', this.item.startDate, this.minDate, this.item.endDate, true)
+      this.formValidator.checkDateFieldValidity('startDate', this.item.startDate, this.minDate, this.startMaxDate, true)
       this.formValidator.checkDateFieldValidity('endDate', this.item.endDate, this.endMinDate, this.maxDate, !this.publisher.context.redactor.optionalPublishTime)
       this.formValidator.checkTextFieldValidity('ressourceUrl', this.item.ressourceUrl, null, 2048, true)
       this.updateItemValidated()
@@ -424,12 +424,11 @@ export default {
       this.updateItemValidated()
     },
     'item.startDate' (newVal) {
-      this.formValidator.checkDateFieldValidity('startDate', newVal, this.minDate, this.item.endDate, true)
+      this.formValidator.checkDateFieldValidity('startDate', newVal, this.minDate, this.startMaxDate, true)
       this.formValidator.checkDateFieldValidity('endDate', this.item.endDate, this.endMinDate, this.maxDate, !this.publisher.context.redactor.optionalPublishTime)
       this.updateItemValidated()
     },
     'item.endDate' (newVal) {
-      this.formValidator.checkDateFieldValidity('startDate', this.item.startDate, this.minDate, newVal, true)
       this.formValidator.checkDateFieldValidity('endDate', newVal, this.endMinDate, this.maxDate, !this.publisher.context.redactor.optionalPublishTime)
       this.updateItemValidated()
     },

--- a/src/test/javascript/spec/services/dateUtils.spec.js
+++ b/src/test/javascript/spec/services/dateUtils.spec.js
@@ -72,4 +72,20 @@ describe('DateUtils.js tests', () => {
     }, 'en')
     expect(result).toStrictEqual('December 9, 2021, 10:55:40 AM')
   })
+
+  it('test 13 DateUtils - min function OK', () => {
+    var date1 = DateUtils.convertDateTimeFromServer('09/12/2021')
+    var date2 = DateUtils.convertDateTimeFromServer('09/12/2022')
+    var result = DateUtils.min(date1, date2)
+    expect(result).toStrictEqual(date1)
+
+    result = DateUtils.min(date1, null)
+    expect(result).toStrictEqual(date1)
+
+    result = DateUtils.min(null, date2)
+    expect(result).toStrictEqual(date2)
+
+    result = DateUtils.min(null, null)
+    expect(result).toStrictEqual(null)
+  })
 })


### PR DESCRIPTION
Corrections des bornes des dates de début et fin de publication : initialement les bornes de la date de début dépendait de la date de fin et les bornes de la date de fin dépendant de la date de début, ce qui pouvait entrainait des problèmes de saisie lorsque les dates étaient dans le passé. Maintenant les bornes de la date de début ne dépendent plus de la date de fin, seuls les bornes de la date de fin s'adapte à la date de début saisie.

closes #166 