### PR TITLE
fix: manage node change on date whitespace

### DIFF
--- a/src/test/javascript/spec/services/dateUtils.spec.js
+++ b/src/test/javascript/spec/services/dateUtils.spec.js
@@ -71,7 +71,7 @@ describe('DateUtils.js tests', () => {
       second: 'numeric'
     }, 'en')
     // warning nodejs version have a change moving from whitespace to a non-breaking whitespace
-    expect(result).stringMatching(new RegExp('December 9, 2021 at 10:55:40(( )|( ))AM'))
+    expect(result).stringMatching(new RegExp('December 9, 2021 at 10:55:40[[:space:]]AM'))
   })
 
   it('test 13 DateUtils - min function OK', () => {

--- a/src/test/javascript/spec/services/dateUtils.spec.js
+++ b/src/test/javascript/spec/services/dateUtils.spec.js
@@ -70,7 +70,8 @@ describe('DateUtils.js tests', () => {
       minute: 'numeric',
       second: 'numeric'
     }, 'en')
-    expect(result).toStrictEqual('December 9, 2021 at 10:55:40 AM')
+    // warning nodejs version have a change moving from whitespace to a non-breaking whitespace
+    expect(result).stringMatching((new RegExp('December 9, 2021 at 10:55:40(( )|( ))AM'))
   })
 
   it('test 13 DateUtils - min function OK', () => {

--- a/src/test/javascript/spec/services/dateUtils.spec.js
+++ b/src/test/javascript/spec/services/dateUtils.spec.js
@@ -71,7 +71,7 @@ describe('DateUtils.js tests', () => {
       second: 'numeric'
     }, 'en')
     // warning nodejs version have a change moving from whitespace to a non-breaking whitespace
-    expect(result).stringMatching((new RegExp('December 9, 2021 at 10:55:40(( )|( ))AM'))
+    expect(result).stringMatching(new RegExp('December 9, 2021 at 10:55:40(( )|( ))AM'))
   })
 
   it('test 13 DateUtils - min function OK', () => {

--- a/src/test/javascript/spec/services/dateUtils.spec.js
+++ b/src/test/javascript/spec/services/dateUtils.spec.js
@@ -71,7 +71,7 @@ describe('DateUtils.js tests', () => {
       second: 'numeric'
     }, 'en')
     // warning nodejs version have a change moving from whitespace to a non-breaking whitespace
-    expect(result).stringMatching(new RegExp('December 9, 2021 at 10:55:40[[:space:]]AM'))
+    expect(result).toMatch(new RegExp('December 9, 2021 at 10:55:40[[:space:]]AM'))
   })
 
   it('test 13 DateUtils - min function OK', () => {

--- a/src/test/javascript/spec/services/dateUtils.spec.js
+++ b/src/test/javascript/spec/services/dateUtils.spec.js
@@ -71,7 +71,7 @@ describe('DateUtils.js tests', () => {
       second: 'numeric'
     }, 'en')
     // warning nodejs version have a change moving from whitespace to a non-breaking whitespace
-    expect(result).toMatch(new RegExp('December 9, 2021 at 10:55:40[[:space:]]AM'))
+    expect(result).toMatch(new RegExp('December 9, 2021 at 10:55:40\\sAM'))
   })
 
   it('test 13 DateUtils - min function OK', () => {


### PR DESCRIPTION
node moved from a whitespace to a non-breaking withespace in dates